### PR TITLE
Allow to build with ghc-8.8 by increasing upper bounds

### DIFF
--- a/bytestring-trie.cabal
+++ b/bytestring-trie.cabal
@@ -73,9 +73,9 @@ Library
     -- The lower bounds are more restrictive than necessary.
     -- But then, we don't maintain any CI tests for older
     -- versions, so these are the lowest bounds we've verified.
-    Build-Depends: base       >= 4.5   && < 4.13
+    Build-Depends: base       >= 4.5   && < 4.14
                  , bytestring >= 0.9.2 && < 0.11
-                 , binary     >= 0.5.1 && < 0.8.7
+                 , binary     >= 0.5.1 && < 0.8.8
     
 ------------------------------------------------------------
 ------------------------------------------------------- fin.


### PR DESCRIPTION
Upper bounds are nonsense, but here we go.