### PR TITLE
Add deleteSubmap

### DIFF
--- a/src/Data/Trie.hs
+++ b/src/Data/Trie.hs
@@ -49,6 +49,10 @@ module Data.Trie
     
     -- * Single-value modification
     , alterBy, insert, adjust, delete
+
+    -- * Something else
+    , deleteSubmap
+    , deleteSubmap'
     
     -- * Combining tries
     , mergeBy, unionL, unionR

--- a/src/Data/Trie/Internal.hs
+++ b/src/Data/Trie/Internal.hs
@@ -54,6 +54,10 @@ module Data.Trie.Internal
     , contextualFilterMap
     , contextualMapBy
 
+    -- * Something else
+    , deleteSubmap
+    , deleteSubmap'
+
     -- * Priority-queue functions
     , minAssoc, maxAssoc
     , updateMinViewBy, updateMaxViewBy


### PR DESCRIPTION
Could you add this new function?

I've been used `bytestring-trie` for many use case, and I implement a function for myself like

    deleteSubmap' key trie =
        foldr
            (\k t -> delete k t)
            trie
            (keys $ submap key trie)

However, because it traverses every deleting target entries, this version is too slow.

Could you add my implementation in the `Data.Trie.Internal`?

I'm not sure that the function's name and actual implementation is proper for your package.
If you care, please rename&change it.