### PR TITLE
Bump Upper Bounds for `base` & `binary` for GHC 9.0.1 & Stackage Nightly

### DIFF
--- a/bytestring-trie.cabal
+++ b/bytestring-trie.cabal
@@ -55,7 +55,9 @@ Tested-With:
     GHC ==8.0.1, GHC ==8.0.2,
     GHC ==8.2.1, GHC ==8.2.2,
     GHC ==8.4.1, GHC ==8.4.2, GHC ==8.4.3,
-    GHC ==8.6.1, GHC ==8.6.2
+    GHC ==8.6.1, GHC ==8.6.2,
+    GHC ==8.10.4,
+    GHC ==9.0.1
 
 Source-Repository head
     Type:     git
@@ -73,9 +75,9 @@ Library
     -- The lower bounds are more restrictive than necessary.
     -- But then, we don't maintain any CI tests for older
     -- versions, so these are the lowest bounds we've verified.
-    Build-Depends: base       >= 4.5   && < 4.13
+    Build-Depends: base       >= 4.5   && < 4.16
                  , bytestring >= 0.9.2 && < 0.11
-                 , binary     >= 0.5.1 && < 0.8.7
+                 , binary     >= 0.5.1 && < 0.10.1
     
 ------------------------------------------------------------
 ------------------------------------------------------- fin.


### PR DESCRIPTION
Bump upper-bound of base to `4.16` & binary to `0.10.1`. 

This lets us build with both `stack build --resolver nightly` & `cabal build -w ghc-9.0.1`. 

I also tested with `cabal build -w ghc-7.10.3` - the oldest GHC available with `ghcup`.