### PR TITLE
Export constructors

### DIFF
--- a/src/Data/Trie/Internal.hs
+++ b/src/Data/Trie/Internal.hs
@@ -38,7 +38,7 @@
 module Data.Trie.Internal
     (
     -- * Data types
-      Trie()
+      Trie(..)
     -- BUG: can't seem to put this at the top: it'll gobble up the
     -- following section name and replace it.  (I'm guessing that's
     -- something to do with the section not having any exported


### PR DESCRIPTION
The `Data.Trie.Internal` documentation says "This module is for developers who need deeper (and less stable) access to the abstract type", but it doesn't provide access to the constructors (unlike `Data.Map.Internal`, for example).

The package is made available with many caveats: its name and its documentation both clearly suggest instability. My opinion is that they should be exported, and the risk that this will break other people's code is a risk they then take on knowingly.